### PR TITLE
Allow to create tag without message

### DIFF
--- a/src/Repository/Tags.php
+++ b/src/Repository/Tags.php
@@ -45,11 +45,11 @@ final class Tags
             ->binary
             ->command()
             ->withArgument('tag')
-            ->withShortOption('a')
             ->withArgument((string) $name);
 
         if (null !== $message) {
             $command = $command
+                ->withShortOption('a')
                 ->withShortOption('m')
                 ->withArgument((string) $message);
         }

--- a/src/Repository/Tags.php
+++ b/src/Repository/Tags.php
@@ -39,18 +39,22 @@ final class Tags
         return $this;
     }
 
-    public function add(Name $name, Message $message): self
+    public function add(Name $name, Message $message = null): self
     {
-        ($this->binary)(
-            $this
-                ->binary
-                ->command()
-                ->withArgument('tag')
-                ->withShortOption('a')
-                ->withArgument((string) $name)
+        $command = $this
+            ->binary
+            ->command()
+            ->withArgument('tag')
+            ->withShortOption('a')
+            ->withArgument((string) $name);
+
+        if (null !== $message) {
+            $command = $command
                 ->withShortOption('m')
-                ->withArgument((string) $message)
-        );
+                ->withArgument((string) $message);
+        }
+
+        ($this->binary)($command);
 
         return $this;
     }

--- a/tests/Repository/TagsTest.php
+++ b/tests/Repository/TagsTest.php
@@ -67,7 +67,7 @@ class TagsTest extends TestCase
             ->expects($this->once())
             ->method('execute')
             ->with($this->callback(function($command): bool {
-                return (string) $command === "git 'tag' '-a' '1.0.0' '-m' 'first release'" &&
+                return (string) $command === "git 'tag' '1.0.0' '-a' '-m' 'first release'" &&
                     $command->workingDirectory() === '/tmp/foo';
             }))
             ->willReturn($process = $this->createMock(Process::class));
@@ -103,7 +103,7 @@ class TagsTest extends TestCase
             ->expects($this->once())
             ->method('execute')
             ->with($this->callback(function($command): bool {
-                return (string) $command === "git 'tag' '-a' '1.0.0'" &&
+                return (string) $command === "git 'tag' '1.0.0'" &&
                     $command->workingDirectory() === '/tmp/foo';
             }))
             ->willReturn($process = $this->createMock(Process::class));

--- a/tests/Repository/TagsTest.php
+++ b/tests/Repository/TagsTest.php
@@ -92,6 +92,42 @@ class TagsTest extends TestCase
         );
     }
 
+    public function testAddWithoutMessage()
+    {
+        $server = $this->createMock(Server::class);
+        $server
+            ->expects($this->once())
+            ->method('processes')
+            ->willReturn($processes = $this->createMock(Processes::class));
+        $processes
+            ->expects($this->once())
+            ->method('execute')
+            ->with($this->callback(function($command): bool {
+                return (string) $command === "git 'tag' '-a' '1.0.0'" &&
+                    $command->workingDirectory() === '/tmp/foo';
+            }))
+            ->willReturn($process = $this->createMock(Process::class));
+        $process
+            ->expects($this->once())
+            ->method('wait')
+            ->will($this->returnSelf());
+        $process
+            ->method('exitCode')
+            ->willReturn(new ExitCode(0));
+
+        $tags = new Tags(
+            new Binary(
+                $server,
+                new Path('/tmp/foo')
+            )
+        );
+
+        $this->assertSame(
+            $tags,
+            $tags->add(new Name('1.0.0'))
+        );
+    }
+
     public function testSign()
     {
         $server = $this->createMock(Server::class);


### PR DESCRIPTION
When you create an unsigned tag, the message is optional.