### PR TITLE
Improve assertions and fix NameTest class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   phpunit:

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "phpunit/phpunit": "~8.0",
         "symfony/filesystem": "~5.0",
         "giorgiosironi/eris": "^0.11.0",
-        "vimeo/psalm": "~3.7.0"
+        "vimeo/psalm": "^3.7"
     },
     "scripts": {
         "test": "vendor/bin/phpunit --colors=always"

--- a/tests/Repository/Remote/NameTest.php
+++ b/tests/Repository/Remote/NameTest.php
@@ -13,7 +13,7 @@ use Eris\{
     TestTrait
 };
 
-class BranchTest extends TestCase
+class NameTest extends TestCase
 {
     use TestTrait;
 

--- a/tests/RepositoryTest.php
+++ b/tests/RepositoryTest.php
@@ -180,10 +180,10 @@ class RepositoryTest extends TestCase
             $this->createMock(Clock::class)
         );
 
-        $this->assertFalse(is_dir('/tmp/foo/.git'));
+        $this->assertDirectoryNotExists('/tmp/foo/.git');
         $this->assertNull($repo->init());
         $this->assertNull($repo->init()); //validate reinit doesn't throw
-        $this->assertTrue(is_dir('/tmp/foo/.git'));
+        $this->assertDirectoryExists('/tmp/foo/.git');
     }
 
     /**


### PR DESCRIPTION
# Changed log

- Improve assertions about `assertDirectoryNotExists` and `assertDirectoryExists`.
- Fix namespace for `NameTest` class.
- Add `pull_request` trigger on GitHub action.
- To install latest Psalm version, it should define `^3.7` for `psalm` dependency.